### PR TITLE
Fix Bug with showing wrong Searchparameters

### DIFF
--- a/src/main/js/bundles/dn_querybuilder/QueryBuilderWidgetModel.js
+++ b/src/main/js/bundles/dn_querybuilder/QueryBuilderWidgetModel.js
@@ -253,6 +253,9 @@ export default declare({
         this.loading = true;
         const fieldData = this._getSelectedFieldData(selectedStoreId);
         apprt_when(fieldData, (fields) => {
+            if (!fields) {
+                return;
+            }
             const firstField = fields[0];
             const addedFieldQuery = {
                 fields: fields,
@@ -533,7 +536,7 @@ export default declare({
         const newStores = stores.slice(0);
         newStores.splice(index, 1);
         this.stores = newStores;
-        if (!this._selectedStoreStillAvailable(newStores) && newStores.length) {
+        if (!this._selectedStoreStillAvailable(newStores)) {
             this.selectedStoreId = null;
         }
         this.getStoreDataFromMetadata();


### PR DESCRIPTION
Fixed bug when changing the layer to search on.
If there is only one layer (Layer A) in the list, then you first deselect Layer A in the ToC and then select another Layer (Layer B), you can only choose from the searchparameters from Layer A.