### PR TITLE
Fix Query not working when switching to $in with non-empty, non-array value

### DIFF
--- a/src/main/js/bundles/dn_querybuilder/FieldWidget.vue
+++ b/src/main/js/bundles/dn_querybuilder/FieldWidget.vue
@@ -391,11 +391,11 @@
             },
             relationalOperatorChanged: function (relationalOperator, fieldQuery) {
                 const selectedField = this.selectedField;
-                if (fieldQuery.value === null || fieldQuery.value === "") { /* only if no value was selected*/
+                if (relationalOperator === "$in") {
+                    fieldQuery.value = [];
+                } else if (fieldQuery.value === null || fieldQuery.value === "") { /* only if no value was selected*/
                     if (relationalOperator === "$exists") {
                         fieldQuery.value = true;
-                    } else if (relationalOperator === "$in") {
-                        fieldQuery.value = [];
                     } else {
                         if (selectedField.type === "date") {
                             fieldQuery.value = "";


### PR DESCRIPTION
reorder if statements to always set value to [] when switching to $in

Workflow of Problem occurring in sample app:
-Open Query Builder via Eigene Abfrage Erstellen
-Select Countries as Source Store
-Set Query to Name $eq Afghanistan
-Set Operator to $in
-Start Querying
-Get Error operator '$in' expects an array as value type but got '"Afghanistan"' -Clear Value Afghanistan via X
-Set Value to Afghanistan
-Start Querying
-Get correct Result