### PR TITLE
Allow costum stores + make operators configurable in manifest.json

### DIFF
--- a/src/main/js/bundles/dn_querybuilder/EditableQueryBuilderWidgetFactory.js
+++ b/src/main/js/bundles/dn_querybuilder/EditableQueryBuilderWidgetFactory.js
@@ -81,7 +81,7 @@ export default class EditableQueryBuilderWidgetFactory {
             model.getDistinctValues(args.value, args.selectedField, vm.selectedStoreId);
         });
         this.#queryBuilderWidgetModelBinding = Binding.for(vm, model)
-            .syncAll("replaceOpenedTables")
+            .syncAll("replaceOpenedTables", "operators")
             .enable()
             .syncToLeftNow();
 

--- a/src/main/js/bundles/dn_querybuilder/FieldWidget.vue
+++ b/src/main/js/bundles/dn_querybuilder/FieldWidget.vue
@@ -290,6 +290,12 @@
             showFieldInfos: {
                 type: Boolean,
                 default: false
+            },
+            operators: {
+                type: Object,
+                default: () => {
+                    return {default:{default: []}};
+                }
             }
         },
         data() {
@@ -388,13 +394,12 @@
                 const selectedField = this.selectedField;
                 this.getDistinctValues(value, selectedField);
                 if (selectedField.type === "date") {
-                    fieldQuery.value = null;
-                    fieldQuery.relationalOperator = "$lte";
+                    fieldQuery.value = new Date();
                 } else {
                     fieldQuery.value = (selectedField.codedValues[0]
                         && selectedField.codedValues[0].code) || selectedField.distinctValues[0] || "";
-                    fieldQuery.relationalOperator = "$eq";
                 }
+                fieldQuery.relationalOperator = this.getRelationalOperators(selectedField)[0].value;
                 if (fieldQuery.relationalOperator === "$exists") {
                     fieldQuery.value = true;
                 }
@@ -408,7 +413,7 @@
                         fieldQuery.value = true;
                     } else {
                         if (selectedField.type === "date") {
-                            fieldQuery.value = "";
+                            fieldQuery.value = new Date();
                         } else {
                             fieldQuery.value = (selectedField.codedValues[0]
                                 && selectedField.codedValues[0].code) || selectedField.distinctValues[0] || "";
@@ -426,59 +431,24 @@
                 if (!field) {
                     return [];
                 }
-                const type = field.type;
-                switch (type) {
-                    case "codedvalue":
-                        return [
-                            {value: "$eq", text: this.i18n.relationalOperators.is},
-                            {value: "!$eq", text: this.i18n.relationalOperators.is_not},
-                            {value: "$gt", text: this.i18n.relationalOperators.is_greater_than},
-                            {value: "$gte", text: this.i18n.relationalOperators.is_greater_or_equal},
-                            {value: "$lt", text: this.i18n.relationalOperators.is_less_than},
-                            {value: "$lte", text: this.i18n.relationalOperators.is_less_or_equal},
-                            {value: "$exists", text: this.i18n.relationalOperators.exists}
-                        ];
-                    case "boolean":
-                        return [
-                            {value: "$eq", text: this.i18n.relationalOperators.is},
-                            {value: "!$eq", text: this.i18n.relationalOperators.is_not},
-                            {value: "$exists", text: this.i18n.relationalOperators.exists}
-                        ];
-                    case "string":
-                    case "guid":
-                    case "global-id":
-                        return [
-                            {value: "$eq", text: this.i18n.relationalOperators.is},
-                            {value: "!$eq", text: this.i18n.relationalOperators.is_not},
-                            {value: "$eqw", text: this.i18n.relationalOperators.eqw},
-                            {value: "$suggest", text: this.i18n.relationalOperators.suggest},
-                            {value: "$exists", text: this.i18n.relationalOperators.exists},
-                            {value: "$in", text: this.i18n.relationalOperators.in}
-                        ];
-                    case "number":
-                        return [
-                            {value: "$eq", text: this.i18n.relationalOperators.is},
-                            {value: "!$eq", text: this.i18n.relationalOperators.is_not},
-                            {value: "$gt", text: this.i18n.relationalOperators.is_greater_than},
-                            {value: "$gte", text: this.i18n.relationalOperators.is_greater_or_equal},
-                            {value: "$lt", text: this.i18n.relationalOperators.is_less_than},
-                            {value: "$lte", text: this.i18n.relationalOperators.is_less_or_equal},
-                            {value: "$exists", text: this.i18n.relationalOperators.exists},
-                            {value: "$in", text: this.i18n.relationalOperators.in}
-                        ];
-                    case "date":
-                        return [
-                            {value: "$lte", text: this.i18n.relationalOperators.before},
-                            {value: "$gte", text: this.i18n.relationalOperators.after},
-                            {value: "$exists", text: this.i18n.relationalOperators.exists}
-                        ];
-                    default:
-                        return [
-                            {value: "$eq", text: this.i18n.relationalOperators.is},
-                            {value: "!$eq", text: this.i18n.relationalOperators.is_not},
-                            {value: "$exists", text: this.i18n.relationalOperators.exists}
-                        ];
+                let type = field.type;
+                //console.log(field)
+                let operators = [];
+                //console.log(this.operators[field.operatorClass], field.operatorClass, this.operators.default[type]);
+                if (type === "guid" || type === "global-id"){
+                    type = "string";
                 }
+                if(field.operatorClass && this.operators[field.operatorClass]){
+                    operators = this.operators[field.operatorClass][type];
+                }
+                else{
+                    operators = this.operators.default[type];
+                }
+                if(!operators){
+                    operators = this.operators.default.default;
+                }
+                return operators;
+
             },
             getDistinctValues(value, selectedField) {
                 this.$root.$emit("getDistinctValues", {value, selectedField});

--- a/src/main/js/bundles/dn_querybuilder/FieldWidget.vue
+++ b/src/main/js/bundles/dn_querybuilder/FieldWidget.vue
@@ -432,9 +432,7 @@
                     return [];
                 }
                 let type = field.type;
-                //console.log(field)
                 let operators = [];
-                //console.log(this.operators[field.operatorClass], field.operatorClass, this.operators.default[type]);
                 if (type === "guid" || type === "global-id"){
                     type = "string";
                 }

--- a/src/main/js/bundles/dn_querybuilder/MetadataAnalyzer.js
+++ b/src/main/js/bundles/dn_querybuilder/MetadataAnalyzer.js
@@ -74,7 +74,8 @@ export default class MetadataAnalyzer {
                                 type: field.type,
                                 codedValues: codedValues,
                                 distinctValues: [],
-                                loading: false
+                                loading: false,
+                                operatorClass: field.operatorClass
                             });
                         }
                     });

--- a/src/main/js/bundles/dn_querybuilder/QueryBuilderWidget.vue
+++ b/src/main/js/bundles/dn_querybuilder/QueryBuilderWidget.vue
@@ -245,6 +245,7 @@
                     :enable-distinct-values="enableDistinctValues"
                     :show-field-infos="visibleElements.fieldInfos"
                     :i18n="i18n"
+                    :operators="operators"
                     @remove="removeField"
                     @add="addField"
                 />
@@ -421,7 +422,8 @@
                 linkOperatorsDisabled: true,
                 ariaLabelAdded: false,
                 textToRead: "",
-                replaceOpenedTables: false
+                replaceOpenedTables: false,
+                operators: {default:{default:[]}}
             };
         },
         computed: {

--- a/src/main/js/bundles/dn_querybuilder/QueryBuilderWidgetFactory.js
+++ b/src/main/js/bundles/dn_querybuilder/QueryBuilderWidgetFactory.js
@@ -99,7 +99,7 @@ export default class QueryBuilderWidgetFactory {
                 "activeSpatialInputAction", "allowMultipleSpatialInputs", "negateSpatialInput", "replaceOpenedTables")
             .syncAllToLeft("locale", "storeData", "sortFieldData", "enableDistinctValues",
                 "spatialInputActions", "activeSpatialInputActionDescription",
-                "loading", "processing", "activeTool")
+                "loading", "processing", "activeTool", "operators")
             .enable()
             .syncToLeftNow();
     }

--- a/src/main/js/bundles/dn_querybuilder/QueryController.js
+++ b/src/main/js/bundles/dn_querybuilder/QueryController.js
@@ -81,8 +81,13 @@ export default class QueryController {
         }
 
         let query = this.#query = countFilter.query({}, { count: 0 });
-        return apprt_when(query.total, async (total) => {
-            if (total) {
+        let totalInQuery = true;
+        if(!query.total){
+            query.total= query;
+            totalInQuery = false;
+        }
+        return apprt_when(query.total, async (res) => {
+            if (res && totalInQuery || res.total ) {
                 // smartfinder
                 if (this._smartfinderComplexQueryHandler && store.coreName) {
                     this._smartfinderComplexQueryHandler.setComplexQuery(complexQuery);

--- a/src/main/js/bundles/dn_querybuilder/README.md
+++ b/src/main/js/bundles/dn_querybuilder/README.md
@@ -218,7 +218,52 @@ To use a store with the Query Builder bundle, add the value _querybuilder_ to th
                 ],
                 "width": "2px"
             }
-        }
+        },
+        "operators": {
+            "default" : {
+                "codedvalue": [
+                    {"value": "$eq", "text": "${ui.relationalOperators.is}"},
+                    {"value": "!$eq", "text": "${ui.relationalOperators.is_not}"},
+                    {"value": "$gt", "text": "${ui.relationalOperators.is_greater_than}"},
+                    {"value": "$gte", "text": "${ui.relationalOperators.is_greater_or_equal}"},
+                    {"value": "$lt", "text": "${ui.relationalOperators.is_less_than}"},
+                    {"value": "$lte", "text": "${ui.relationalOperators.is_less_or_equal}"},
+                    {"value": "$exists", "text": "${ui.relationalOperators.exists}"}
+                ],
+                "boolean": [
+                    {"value": "$eq", "text": "${ui.relationalOperators.is}"},
+                    {"value": "!$eq", "text": "${ui.relationalOperators.is_not}"},
+                    {"value": "$exists", "text": "${ui.relationalOperators.exists}"}
+                ],
+                "string": [
+                    {"value": "$eq", "text": "${ui.relationalOperators.is}"},
+                    {"value": "!$eq", "text": "${ui.relationalOperators.is_not}"},
+                    {"value": "$eqw", "text": "${ui.relationalOperators.eqw}"},
+                    {"value": "$suggest", "text": "${ui.relationalOperators.suggest}"},
+                    {"value": "$exists", "text": "${ui.relationalOperators.exists}"},
+                    {"value": "$in", "text": "${ui.relationalOperators.in}"}
+                ],
+                "number":   [
+                    {"value": "$eq", "text": "${ui.relationalOperators.is}"},
+                    {"value": "!$eq", "text": "${ui.relationalOperators.is_not}"},
+                    {"value": "$gt", "text": "${ui.relationalOperators.is_greater_than}"},
+                    {"value": "$gte", "text": "${ui.relationalOperators.is_greater_or_equal}"},
+                    {"value": "$lt", "text": "is_less_than"},
+                    {"value": "$lte", "text": "${ui.relationalOperators.is_less_or_equal}"},
+                    {"value": "$exists", "text": "${ui.relationalOperators.exists}"},
+                    {"value": "$in", "text": "${ui.relationalOperators.in}"}
+                ],
+                "date": [
+                    {"value": "$lte", "text": "${ui.relationalOperators.before}"},
+                    {"value": "$gte", "text": "${ui.relationalOperators.after}"},
+                    {"value": "$exists", "text": "${ui.relationalOperators.exists}"}
+                ],
+                "default": [
+                    {"value": "$eq", "text": "${ui.relationalOperators.is}"},
+                    {"value": "!$eq", "text": "${ui.relationalOperators.is_not}"},
+                    {"value": "$exists", "text": "${ui.relationalOperators.exists}"}
+                ]
+            }
     }
 }
 ```
@@ -236,6 +281,7 @@ To use a store with the Query Builder bundle, add the value _querybuilder_ to th
 | hiddenFields                     | Array   |                                                         | ```[]```         | Names of fields that should be hidden in the field select                                                                                               |
 | hiddenSortFields                 | Array   |                                                         | ```[]```         | Names of fields that should be hidden in the sort field select                                                                                          |
 | symbols                          | Object  |                                                         |                  | Symbols that will be used for the presentation of geometries that are selected via the spatial input actions.                                           |
+| operators | Object |  | | Specify the allowed operators when formulating a costum query. All provided information is option, if no information is given the default will be chosen. You could also provide additional field types. Further, you can add a specififc `operatorClass` to the fieds ans specify the opertors here like: `{"operators": {default {...}, operatorClass: {...}}}`
 
 ### QueryTools:
 ```


### PR DESCRIPTION
With this pull request we want to introduce the possibility to make costum stores queryable by the dn_querybuilder. 
Therfore we adress two main components.

- Handling a request promise without a total promise.
  - Therefore we proof in QueryController.js wether a total promise is attached. If this it not the cas it just waits until the primary promise resolves
- Allow to configure the availabe comparison parameters
  - Here it is possible to overwrite in the app.json or manifest.json the "operations" parameter. 
      -  parameters for the "default" can be overwritten or a new field type can be added
      - a new operator Class can be creatred. Here the field then must have an attribute with the matchin operator Class
      
 The documentation in the Readme is currently quite rudimentary, please comment if it should be extended