### PR TITLE
Show Name of typeIdField instea of code

### DIFF
--- a/src/main/js/bundles/dn_querybuilder-config/FieldWidget.js
+++ b/src/main/js/bundles/dn_querybuilder-config/FieldWidget.js
@@ -23,9 +23,7 @@ import Memory from "dojo/store/Memory";
 
 import _Connect from "ct/_Connect";
 import apprt_when from "apprt-core/when";
-import apprt_request from "apprt-request";
-// TODO: Replace apprt-request with apprt-fetch
-// https://demos.conterra.de/mapapps/resources/jsregistry/root/apprt-fetch/latest/README.md
+import {apprtFetchJson} from "apprt-fetch";
 import ct_css from "ct/util/css";
 
 import {executeQueryJSON} from "esri/rest/query";
@@ -592,12 +590,11 @@ export default declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _
     },
 
     queryMetadata(url) {
-        return apprt_request(url,
+        return apprtFetchJson(url,
             {
                 query: {
                     f: 'json'
-                },
-                handleAs: 'json'
+                }
             });
     }
 });

--- a/src/main/js/bundles/dn_querybuilder/MetadataAnalyzer.js
+++ b/src/main/js/bundles/dn_querybuilder/MetadataAnalyzer.js
@@ -52,6 +52,13 @@ export default class MetadataAnalyzer {
                                 }
                             }
                         }
+                        if(metadata.typeIdField){
+                            if (domainsFromTypes[metadata.typeIdField]) {
+                                domainsFromTypes[metadata.typeIdField].push({code: type.id, name: type.name});
+                            } else {
+                                domainsFromTypes[metadata.typeIdField] = [{code: type.id, name: type.name}];
+                            }
+                        }
                     });
 
                     const fields = metadata.fields;

--- a/src/main/js/bundles/dn_querybuilder/MetadataAnalyzer.js
+++ b/src/main/js/bundles/dn_querybuilder/MetadataAnalyzer.js
@@ -16,9 +16,7 @@
 import apprt_when from "apprt-core/when";
 import Promise from "apprt-core/Promise";
 import ServiceResolver from "apprt/ServiceResolver";
-import apprt_request from "apprt-request";
-// TODO: Replace apprt-request with apprt-fetch
-// https://demos.conterra.de/mapapps/resources/jsregistry/root/apprt-fetch/latest/README.md
+import { apprtFetchJson } from "apprt-fetch";
 
 export default class MetadataAnalyzer {
 
@@ -181,9 +179,8 @@ export default class MetadataAnalyzer {
                     } else if (fieldData.type === "number") {
                         query.where = "1=1";
                     }
-                    this.#distinctValueQuery = apprt_request(store.target + "/query", {
-                        query: query,
-                        handleAs: 'json'
+                    this.#distinctValueQuery = apprtFetchJson(store.target + "/query", {
+                        query: query
                     }).then((result) => {
                         const distinctValues = [];
                         result.features?.forEach((feature) => {
@@ -238,12 +235,11 @@ export default class MetadataAnalyzer {
     }
 
     queryMetadata(url) {
-        return apprt_request(url,
+        return apprtFetchJson(url,
             {
                 query: {
                     f: 'json'
-                },
-                handleAs: 'json'
+                }
             });
     }
 }


### PR DESCRIPTION
In the file Metadatanalyzer.js after Line 43 the code adds for each type the domains and keys into a file. However, the type can not only have domains but also a code and a name. The code could be referrenced by an attribute from the Feature which is then set as typeIdField. I adjusted the code, so that name is shown instead of the code when the typeIdFiled is added to the query. Further, I replaced apprt-request with apprt-fetch.