### PR TITLE
Rename query sequence property

### DIFF
--- a/src/main/js/bundles/dn_querybuilder/CachingStore.js
+++ b/src/main/js/bundles/dn_querybuilder/CachingStore.js
@@ -38,7 +38,7 @@ export default declare([], {
     idList: null,
     masterStore: null,
     initialQuery: null,
-    querySequenz: null,
+    querySequence: null,
 
     constructor(args) {
         args = args || {};


### PR DESCRIPTION
## Summary
- fix property name in `CachingStore` to `querySequence`

## Testing
- `mvn -q test -P run-js-tests,include-mapapps-deps` *(fails: `mvn` not found)*