### PR TITLE
fix #101 Filter UI is not updated after all filters are removed

### DIFF
--- a/src/main/js/bundles/dn_querybuilder/FilterActionDefinitionFactory.ts
+++ b/src/main/js/bundles/dn_querybuilder/FilterActionDefinitionFactory.ts
@@ -93,6 +93,7 @@ export default class FilterActionDefinitionFactory {
                         break;
                     case "resetFilterAction":
                         ref.definitionExpression = ref._initialDefinitionExpression;
+                        ref._complexQuery = { "$and": [{1: {"$eq": 1}}]};
                         break;
                 }
             }


### PR DESCRIPTION
This fix resets the layer's complex query which is used to initialize the UI. Now the next time the UI is created, all filters are cleared.